### PR TITLE
update setup.py to enable installing via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='deepexplain',
       version='0.1',
@@ -7,7 +7,7 @@ setup(name='deepexplain',
       author='Marco Ancona (ETH Zurich)',
       author_email='marco.ancona@inf.ethz.ch',
       license='MIT',
-      packages=['deepexplain'],
+      packages=find_packages(),
       install_requires=[
             'scipy',
             'matplotlib',


### PR DESCRIPTION
This pull request is to enable installing DeepExplain via pip in default mode (i.e. not editable):
`pip install git+https://github.com/marcoancona/DeepExplain.git`

Before, this would result in the error `ModuleNotFoundError: No module named 'deepexplain.tensorflow'` as the packages are not all configured in setup.py